### PR TITLE
Fix #25 :  Prevent the frame to go outside the screen when it's scaling change

### DIFF
--- a/Source/libs/EditModeExpanded-1.0/EditModeExpanded-1.0.lua
+++ b/Source/libs/EditModeExpanded-1.0/EditModeExpanded-1.0.lua
@@ -184,6 +184,8 @@ function lib:RegisterFrame(frame, name, db)
 	frame.snappedFrames = {};
     frame.Selection:EnableKeyboard();
     frame.Selection:SetPropagateKeyboardInput(true);
+    -- prevent the frame to go outside the screen
+    frame:SetClampedToScreen(true);
     
     function frame.UpdateMagnetismRegistration() end
 


### PR DESCRIPTION
Well, it was easier than expected ^^

With this settings the frame should always be in the screen view (even when its scaling change)
I've tested this on the beta and so far it seems to resolve the issue

let me known if it's good for you

