### PR TITLE
Fix lua error when 'RegisterFrame' is not used

### DIFF
--- a/Source/libs/EditModeExpanded-1.0/EditModeExpanded-1.0.lua
+++ b/Source/libs/EditModeExpanded-1.0/EditModeExpanded-1.0.lua
@@ -3,7 +3,7 @@
 --
 
 local CURRENT_BUILD = "10.0.5"
-local MAJOR, MINOR = "EditModeExpanded-1.0", 48
+local MAJOR, MINOR = "EditModeExpanded-1.0", 49
 local lib = LibStub:NewLibrary(MAJOR, MINOR)
 if not lib then return end
 
@@ -674,7 +674,7 @@ hooksecurefunc(EditModeManagerFrame, "ExitEditMode", function()
 end)
 
 hooksecurefunc(EditModeManagerFrame, "SelectSystem", function(self, systemFrame)
-    if EditModeExpandedSystemSettingsDialog.attachedToSystem ~= systemFrame then
+    if EditModeExpandedSystemSettingsDialog and EditModeExpandedSystemSettingsDialog.attachedToSystem ~= systemFrame then
         EditModeExpandedSystemSettingsDialog:Hide()
     end
     


### PR DESCRIPTION
If we import this lib, and no addon called `RegisterFrame` function, a lua error will happen when we try to select a box in Edit Mode.
```
3x ...I/Libs/EditModeExpanded-1.0-48/EditModeExpanded-1.0.lua:677: attempt to index global 'EditModeExpandedSystemSettingsDialog' (a nil value)
```
So add a nil check to avoid this situation