### PR TITLE
Close dialog of system frame when click custom frame in EditMode

### DIFF
--- a/Source/libs/EditModeExpanded-1.0/EditModeExpanded-1.0.lua
+++ b/Source/libs/EditModeExpanded-1.0/EditModeExpanded-1.0.lua
@@ -238,6 +238,7 @@ function lib:RegisterFrame(frame, name, db, anchorTo, anchorPoint)
             self.Selection:ShowSelected();
             self.isSelected = true;
             if framesDialogs[self.system] then
+		EditModeManagerFrame:ClearSelectedSystem()  -- be aware of taint
                 EditModeExpandedSystemSettingsDialog:AttachToSystemFrame(self)
             else
                 EditModeExpandedSystemSettingsDialog:Hide()


### PR DESCRIPTION
I try to test whether add this line will taint something. (TalkingHeadFrame for example)
```
for k, v in pairs(TalkingHeadFrame) do
    if not issecurevariable(TalkingHeadFrame, k) then
        print(select(2, issecurevariable(TalkingHeadFrame, k)), k, v)
    end
end

for k, v in pairs(EditModeSystemSettingsDialog) do
    if not issecurevariable(EditModeSystemSettingsDialog, k) then
        print(select(2, issecurevariable(EditModeSystemSettingsDialog, k)), k, v)
    end
end

for k, v in pairs(EditModeManagerFrame) do
    if not issecurevariable(EditModeManagerFrame, k) then
        print(select(2, issecurevariable(EditModeManagerFrame, k)), k, v)
    end
end
```
And I found nothing taint. Maybe we can use `EditModeManagerFrame:ClearSelectedSystem()` in our code I think. #73

I just open a pull request, and you check whether I make a mistake in someplace. Thank you :)