### PR TITLE
Urgent! issue in last commit

### DIFF
--- a/Source/libs/EditModeExpanded-1.0/EditModeExpanded-1.0.lua
+++ b/Source/libs/EditModeExpanded-1.0/EditModeExpanded-1.0.lua
@@ -1184,43 +1184,44 @@ end
 --
 function getOffsetXY(frame, x, y)
     local scale = frame:GetScale()
-    
+    local parentscale = frame.EMEanchorTo == UIParent and 1 or frame.EMEanchorTo:GetScale()
+
     local anchorPoint = frame.EMEanchorPoint or "BOTTOMLEFT"
     if anchorPoint == "BOTTOMLEFT" then
         local targetX, targetY = frame.EMEanchorTo:GetRect()
-        return x - targetX, y - targetY
+        return x - ((targetX * parentscale) / scale), y - ((targetY * parentscale) / scale)
     elseif anchorPoint == "BOTTOMRIGHT" then
         local targetX, targetY, targetWidth = frame.EMEanchorTo:GetRect()
         local width = frame:GetSize()
-        return (x + width) - ((targetX + targetWidth) / scale), y - (targetY / scale)
+        return (x + width) - (((targetX + targetWidth) * parentscale) / scale), y - ((targetY * parentscale) / scale)
     elseif anchorPoint == "TOPLEFT" then
         local targetX, targetY, _, targetHeight = frame.EMEanchorTo:GetRect()
         local _, height = frame:GetSize()
-        return x - (targetX / scale), (y + height) - ((targetY + targetHeight) / scale)
+        return x - ((targetX * parentscale) / scale), (y + height) - (((targetY + targetHeight) * parentscale) / scale)
     elseif anchorPoint == "TOPRIGHT" then
         local targetX, targetY, targetWidth, targetHeight = frame.EMEanchorTo:GetRect()
         local width, height = frame:GetSize()
-        return (x + width) - ((targetX + targetWidth) / scale), (y + height) - ((targetY + targetHeight) / scale)
+        return (x + width) - (((targetX + targetWidth) * parentscale) / scale), (y + height) - (((targetY + targetHeight) * parentscale) / scale)
     elseif anchorPoint == "CENTER" then
         local targetX, targetY, targetWidth, targetHeight = frame.EMEanchorTo:GetRect()
         local width, height = frame:GetSize()
-        return (x + 0.5 * width) - ((targetX + 0.5 * targetWidth) / scale), (y + 0.5 * height) - ((targetY + 0.5 * targetHeight) / scale)
+        return (x + 0.5 * width) - (((targetX + 0.5 * targetWidth) * parentscale) / scale), (y + 0.5 * height) - (((targetY + 0.5 * targetHeight) * parentscale) / scale)
     elseif anchorPoint == "TOP" then
         local targetX, targetY, targetWidth, targetHeight = frame.EMEanchorTo:GetRect()
         local width, height = frame:GetSize()
-        return (x + 0.5 * width) - ((targetX + 0.5 * targetWidth) / scale), (y + height) - ((targetY + targetHeight) / scale)
+        return (x + 0.5 * width) - (((targetX + 0.5 * targetWidth) * parentscale) / scale), (y + height) - (((targetY + targetHeight) * parentscale) / scale)
     elseif anchorPoint == "BOTTOM" then
         local targetX, targetY, targetWidth = frame.EMEanchorTo:GetRect()
         local width = frame:GetSize()
-        return (x + 0.5 * width) - ((targetX + 0.5 * targetWidth) / scale), y - (targetY / scale)
+        return (x + 0.5 * width) - (((targetX + 0.5 * targetWidth) * parentscale) / scale), y - ((targetY * parentscale) / scale)
     elseif anchorPoint == "LEFT" then
         local targetX, targetY, _, targetHeight = frame.EMEanchorTo:GetRect()
         local _, height = frame:GetSize()
-        return x - (targetX / scale), (y + 0.5 * height) - ((targetY + 0.5 * targetHeight) / scale)
+        return x - ((targetX * parentscale) / scale), (y + 0.5 * height) - (((targetY + 0.5 * targetHeight) * parentscale) / scale)
     elseif anchorPoint == "RIGHT" then
         local targetX, targetY, targetWidth, targetHeight = frame.EMEanchorTo:GetRect()
         local width, height = frame:GetSize()
-        return (x + width) - ((targetX + targetWidth) / scale), (y + 0.5 * height) - ((targetY + 0.5 * targetHeight) / scale)
+        return (x + width) - (((targetX + targetWidth) * parentscale) / scale), (y + 0.5 * height) - (((targetY + 0.5 * targetHeight) * parentscale) / scale)
     end 
 end
 

--- a/Source/libs/EditModeExpanded-1.0/EditModeExpanded-1.0.lua
+++ b/Source/libs/EditModeExpanded-1.0/EditModeExpanded-1.0.lua
@@ -1183,8 +1183,8 @@ end
 -- Handle frame being based on a frame other than UIParent
 --
 function getOffsetXY(frame, x, y)
-    local scale = frame:GetScale()
-    local parentscale = frame.EMEanchorTo == UIParent and 1 or frame.EMEanchorTo:GetScale()
+    local scale = frame:GetEffectiveScale()
+    local parentscale = frame.EMEanchorTo:GetEffectiveScale()
 
     local anchorPoint = frame.EMEanchorPoint or "BOTTOMLEFT"
     if anchorPoint == "BOTTOMLEFT" then


### PR DESCRIPTION
Issue1: I forgot to test when we anchor to a frame that scale is not 1.
For example, it will have position problem when we anchor a frame to Minimap which we already setscale to 0.8.

Issue2: UIParent is totally different from other frames, so I handle it differently
`local parentscale = frame.EMEanchorTo == UIParent and 1 or frame.EMEanchorTo:GetScale()`

This time I test for every type of parent frame(UIParent, other frame with scale 1, other frame with scale not 1) and every anchor, it should not have problem anymore.

I notice that you already publish a release 10.0-053, its my fault, did not run a fully test, sorry

---
ADD: A new discovery, we should use GetEffectiveScale() not GetScale(), because a frame will inherit its parent scale.
And we don't need to handle UIParent differently, when we use GetEffectiveScale() to perform calculate, UIParent is the same as other frame now