### PR TITLE
Add a nil check in getSystemID, and fix lib:IsRegistered

### DIFF
--- a/Source/libs/EditModeExpanded-1.0/EditModeExpanded-1.0.lua
+++ b/Source/libs/EditModeExpanded-1.0/EditModeExpanded-1.0.lua
@@ -55,6 +55,7 @@ local getOffsetXY
 local registerFrameMovableWithArrowKeys
 
 local function getSystemID(frame)
+    if not frame.system then return false end
     if frame.system < STARTING_INDEX then
         return frame.EMESystemID
     end
@@ -507,9 +508,9 @@ end
 -- a simple check of "has this frame been registered with EME" - maybe you want to test if another addon registered it already?
 function lib:IsRegistered(frame)
     local systemID = getSystemID(frame)
-    if not systemID then return false end
+    if not systemID or not framesDB[systemID] then return false end
     
-    if not framesDB[systemID] then return false end
+    return true
 end
 
 -- Is the Expanded frame checkbox checked for this frame?


### PR DESCRIPTION
1. function `getSystemID` do not have nil check, if we call it on a unregistered frame, it will cause an error.
2. function `lib:IsRegistered` seems to have problem, it will never return true, we can't use it to check whether a frame is registered. So tried to modified it.